### PR TITLE
Updating the binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Folium notebooks examples
 
-[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/ocefpaf/folium_notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ocefpaf/folium_notebooks/main)
 
 Some misc notebook showing how to use folium.
 


### PR DESCRIPTION
It seems that the current binder `badge` was pointing to a `master` branch  ( see here: [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/ocefpaf/folium_notebooks) ) but the correct one should be `main`.

I just tested [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ocefpaf/folium_notebooks/main) and it seems to be working.
